### PR TITLE
appending optional port number to JDBC connection URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To instantiate a JDBC connection in your code, you can use a method like this:
 
         String username = dbUri.getUserInfo().split(":")[0];
         String password = dbUri.getUserInfo().split(":")[1];
-        String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + dbUri.getPath();
+        String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + (dbUri.getPort() > 0 ? ":" + dbUri.getPort() : "") + dbUri.getPath();
 
         return DriverManager.getConnection(dbUrl, username, password);
     }
@@ -95,7 +95,7 @@ Alternatively you can use Java for configuration of the `BasicDataSource` in Spr
 
             String username = dbUri.getUserInfo().split(":")[0];
             String password = dbUri.getUserInfo().split(":")[1];
-            String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + dbUri.getPath() + ":" + dbUri.getPort() + dbUri.getPath();
+            String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + (dbUri.getPort() > 0 ? ":" + dbUri.getPort() : "") + dbUri.getPath();
 
             BasicDataSource basicDataSource = new BasicDataSource();
             basicDataSource.setUrl(dbUrl);

--- a/devcenter-java-database-plain-jdbc/src/main/java/com/heroku/example/Main.java
+++ b/devcenter-java-database-plain-jdbc/src/main/java/com/heroku/example/Main.java
@@ -25,7 +25,7 @@ public class Main {
 
         String username = dbUri.getUserInfo().split(":")[0];
         String password = dbUri.getUserInfo().split(":")[1];
-        String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + dbUri.getPath();
+        String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + (dbUri.getPort() > 0 ? ":" + dbUri.getPort() : "") + dbUri.getPath();
 
         return DriverManager.getConnection(dbUrl, username, password);
     }

--- a/devcenter-java-database-spring-java/src/main/java/com/heroku/example/MainConfig.java
+++ b/devcenter-java-database-spring-java/src/main/java/com/heroku/example/MainConfig.java
@@ -18,7 +18,7 @@ public class MainConfig {
 
         String username = dbUri.getUserInfo().split(":")[0];
         String password = dbUri.getUserInfo().split(":")[1];
-        String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + dbUri.getPath();
+        String dbUrl = "jdbc:postgresql://" + dbUri.getHost() + (dbUri.getPort() > 0 ? ":" + dbUri.getPort() : "") + dbUri.getPath();
 
         BasicDataSource basicDataSource = new BasicDataSource();
         basicDataSource.setUrl(dbUrl);


### PR DESCRIPTION
Hi,

from the documentation at
https://devcenter.heroku.com/articles/heroku-postgresql#connecting-in-java
I've read that the port numbers at Heroku PortgreSQL instances aren't always the well known ones.
That's why this patch appends the port number only, if it's available.

Regards
Martin
